### PR TITLE
Shorter AWK script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 ```sh
 cat file.txt
+awk 1 file.txt
 grep '' file.txt
 sort -m file.txt
 sed -n p file.txt
@@ -17,7 +18,6 @@ cp file.txt /dev/stdout
 scp file.txt /dev/stdout
 tail --lines=+0 file.txt
 dd status=none if=file.txt (GNU dd)
-awk '/.*/ { print }' file.txt
 openssl enc -none -in file.txt
 perl -e 'while(<>){print}' file.txt
 curl file:///proc/self/cwd/file.txt


### PR DESCRIPTION
I'm not sure if you're taking pull requests or even want the shortest command line for each, but it's golfing, so why not?

An AWK pattern of `1`, or any nonzero (truthy) value will match every line, and the default action is `{ print }`, so we can leave that off.