### PR TITLE
Replace /dev/stdout with /dev/fd/1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ jq -rRs . file.txt
 perl -pe1 file.txt
 tail -n +1 file.txt
 head -n -0 file.txt # GNU head
+cp file.txt /dev/fd/1
 gcc -E -P -xc file.txt
+scp file.txt /dev/fd/1
 comm file.txt /dev/null # BSD comm
-cp file.txt /dev/stdout
-scp file.txt /dev/stdout
 w3m -dump_source file.txt
 dd status=none if=file.txt # GNU dd
 hexdump -ve '"%c"' file.txt
@@ -42,8 +42,8 @@ git -P grep --no-index -h ^ file.txt
 shuf --random-source=/dev/zero file.txt
 bat --color=never --style=plain file.txt
 diff --line-format=%L /dev/null file.txt
+vim -es --clean '+w! /dev/fd/1' '+q!' file.txt
 python -c 'print(open("file.txt").read()[:-1])'
-vim -es --clean '+w! /dev/stdout' '+q!' file.txt
 ffmpeg -v quiet -f data -i file.txt -map 0:0 -c text -f data -
 emacs -Q --batch --eval '(princ (with-temp-buffer (insert-file-contents "file.txt") (buffer-string)))'
 ```


### PR DESCRIPTION
Because this shaves two bytes. Credits to @steike for pointing it out!

stdout is defined as file descriptor 1 in unistd.h, e.g.: https://github.com/bminor/glibc/blob/master/posix/unistd.h#L211